### PR TITLE
check authorized_keys (fixes #256)

### DIFF
--- a/treehouse-builder
+++ b/treehouse-builder
@@ -178,6 +178,11 @@ function _check_space_left {
     echo "Space left: ${space_left}K"
 }
 
+function _count_authorized_keys_lines {
+    authorized_keys_lines=$(wc -l < mnt/img_root/root/.ssh/authorized_keys)
+    echo "There are ${authorized_keys_lines} line(s) in /root/.ssh/authorized_keys"
+}
+
 function _modify_image {
     echo "Modifying Image"
 
@@ -189,6 +194,7 @@ function _modify_image {
 
     _enable_daemons
     _check_space_left
+    _count_authorized_keys_lines
     _cleanup_chroot
 }
 
@@ -268,6 +274,11 @@ fi
 
 if [[ $space_left -lt $MINIMAL_SPACE_LEFT ]]; then
     echo "Not enough space left."
+    exit 1
+fi
+
+if [[ $authorized_keys_lines -le 1 ]]; then
+    echo "/root/.ssh/authorized_keys has 1 line or less."
     exit 1
 fi
 


### PR DESCRIPTION
Fixes #256 

Is it better to check `$keys` in `30_ssh_keys.sh` and not generate `authorized_keys` at all if something went wrong? It would help keep the addition of lines to `treehouse-builder` minimal too.