### PR TITLE
Don't keep the packages into a single string

### DIFF
--- a/scripts.d/05_add_repos.sh
+++ b/scripts.d/05_add_repos.sh
@@ -9,9 +9,9 @@ is_installed() {
 
 install_stuff() {
     local need_install
-    pkgs="raspbian-archive-keyring apt-transport-https"
+    pkgs=("raspbian-archive-keyring" "apt-transport-https")
 
-    for pkg in $pkgs; do
+    for pkg in ${pkgs[*]}; do
         if ! is_installed "$pkg"; then
             need_install="$need_install $pkg"
             echo "need to install $pkg"
@@ -21,7 +21,7 @@ install_stuff() {
     if [ -n "$need_install" ]; then
         echo "updating package sources"
         _apt update || die "Could not update package sources"
-        _apt install $pkgs
+        _apt install "${pkgs[@]}"
     fi
 }
 

--- a/scripts.d/05_add_repos.sh
+++ b/scripts.d/05_add_repos.sh
@@ -9,7 +9,7 @@ is_installed() {
 
 install_stuff() {
     local need_install
-    pkgs="debian-archive-keyring apt-transport-https"
+    pkgs="raspbian-archive-keyring apt-transport-https"
 
     for pkg in $pkgs; do
         if ! is_installed "$pkg"; then
@@ -21,7 +21,7 @@ install_stuff() {
     if [ -n "$need_install" ]; then
         echo "updating package sources"
         _apt update || die "Could not update package sources"
-        _apt install "$pkgs"
+        _apt install $pkgs
     fi
 }
 


### PR DESCRIPTION
in raspbian the package is called raspbian-archive-keyring; also the missing packages were taken as a single package

i.e:

apt-get install "a b"
will try to install "a b" package, not "a", "b"