### PR TITLE
change autorun file created by autorunonce

### DIFF
--- a/autorunonce
+++ b/autorunonce
@@ -152,7 +152,7 @@ if [ $startplanet = "true" ]; then
     echo
     echo "planet_autorun=true"
     echo
-    echo "if [ \"$planet_autorun\" = true ]; then"
+    echo "if [ \"\$planet_autorun\" = true ]; then"
     echo "  if [ -f /srv/planet/pwd/credentials.yml ]; then"
     echo "    docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -f /srv/planet/pwd/credentials.yml -p planet up -d"
     echo "  else"

--- a/autorunonce
+++ b/autorunonce
@@ -150,11 +150,16 @@ if [ $startplanet = "true" ]; then
     echo "fi"
     echo "sleep 1"
     echo
-    echo "if [ -f /srv/planet/pwd/credentials.yml ]; then"
-    echo "  docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -f /srv/planet/pwd/credentials.yml -p planet up -d"
-    echo "else"
-    echo "  docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -p planet up -d"
+    echo "planet_autorun=true"
+    echo
+    echo "if [ "$planet_autorun" = true ]; then"
+    echo "  if [ -f /srv/planet/pwd/credentials.yml ]; then"
+    echo "    docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -f /srv/planet/pwd/credentials.yml -p planet up -d"
+    echo "  else"
+    echo "    docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -p planet up -d"
+    echo "  fi"
     echo "fi"
+    echo
   } > /boot/autorun
 
   mv /srv/tenalp /srv/planet

--- a/autorunonce
+++ b/autorunonce
@@ -159,7 +159,6 @@ if [ $startplanet = "true" ]; then
     echo "    docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -p planet up -d"
     echo "  fi"
     echo "fi"
-    echo
   } > /boot/autorun
 
   mv /srv/tenalp /srv/planet

--- a/autorunonce
+++ b/autorunonce
@@ -152,7 +152,7 @@ if [ $startplanet = "true" ]; then
     echo
     echo "planet_autorun=true"
     echo
-    echo "if [ "$planet_autorun" = true ]; then"
+    echo "if [ \"$planet_autorun\" = true ]; then"
     echo "  if [ -f /srv/planet/pwd/credentials.yml ]; then"
     echo "    docker-compose -f /srv/planet/planet.yml -f /srv/planet/volumes.yml -f /srv/planet/pwd/credentials.yml -p planet up -d"
     echo "  else"


### PR DESCRIPTION
Fixes treehouses/cli#539

Changes the `autorun` file created in the `autorunonce` file to be compliant with the new `autorun` file format required by `services2.sh`

http://download.treehouses.io/experiment/treehouse-services2-1.img.gz

Use this image when testing