### PR TITLE
make hub-ctrl executable

### DIFF
--- a/scripts.d/33_usb.sh
+++ b/scripts.d/33_usb.sh
@@ -7,3 +7,4 @@ _op _chroot gcc -o hub-ctrl hub-ctrl.c -lusb
 
 mkdir -p mnt/img_root/usr/local/bin/
 _op _chroot mv hub-ctrl usr/local/bin/.
+chmod +x mnt/img_root/usr/local/bin/hub-ctrl


### PR DESCRIPTION
Removed `chmod` from `cli/modules/usb.sh` and added it to builder