### PR TITLE
add fail2ban package (fixes #646)

### DIFF
--- a/scripts.d/16_pkg_install.sh
+++ b/scripts.d/16_pkg_install.sh
@@ -32,6 +32,7 @@ INSTALL_PACKAGES=(
     dnsutils
     pagekite # tunnels command
     sl
+    fail2ban # prevent bruteforcing of sshd
 )
 
 if [[ ${INSTALL_PACKAGES:-} ]] ; then


### PR DESCRIPTION
https://github.com/treehouses/cli/issues/696
- Defaults to ban IP addresses for 10 minutes after 5 failed attempts
- to enter a password at ```ssh pi@ip address ``` prompt.