### PR TITLE
update `pihole_autoruonce` (fixes #694)

### DIFF
--- a/examples/pihole_autorunonce
+++ b/examples/pihole_autorunonce
@@ -107,7 +107,7 @@ sync;sync;sync
 
 sync;sync;sync
 
-case "$(treehouses detectrpi)" in
+case "$(treehouses detect rpi)" in
   RPIZW|RPI3A+)
     treehouses bootoption console
 esac


### PR DESCRIPTION
change `treehouses detectrpi` to `treehouses detect rpi` in `examples/pihole_autorunonce`
- fixes #694 