### PR TITLE
update `Vagrantfile` (fixes #710)

### DIFF
--- a/.vagrant.yml
+++ b/.vagrant.yml
@@ -1,0 +1,3 @@
+#github api key
+#read org access
+#GITHUB_KEY: example_key

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,7 +84,7 @@ Vagrant.configure(2) do |config|
     mkdir -p /vagrant/images
     cd /vagrant
     dos2unix * */* */*/* */*/*/* */*/*/*/* */*/*/*/*/*
-    python get_ssh_keys.py
+    python scripts.d/30_ssh_keys.py
     sudo -u vagrant screen -dmS build sudo bash -c 'export PATH="$PATH:/sbin:/usr/sbin";cd /vagrant;./builder --chroot'
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  vyml = YAML.load_file('./.vagrant.yml')#GITHUB_KEY: key 
+  vyml = YAML.load_file('./.vagrant.yml') #GITHUB_KEY: key 
   github_key = vyml.fetch('GITHUB_KEY')
 
   config.vm.box = "treehouses/buster64"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,6 +89,6 @@ Vagrant.configure(2) do |config|
     dos2unix * */* */*/* */*/*/* */*/*/*/* */*/*/*/*/*
     export GITHUB_KEY='#{github_key}'
     python scripts.d/30_ssh_keys.py
-    sudo -u vagrant screen -dmS build sudo bash -c 'export PATH="$PATH:/sbin:/usr/sbin";cd /vagrant;./builder --chroot'
+    sudo -u vagrant screen -dmS build sudo bash -c 'export PATH="$PATH:/sbin:/usr/sbin";cd /vagrant;./builder --chroot; exec bash'
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,6 +88,7 @@ Vagrant.configure(2) do |config|
     cd /vagrant
     dos2unix * */* */*/* */*/*/* */*/*/*/* */*/*/*/*/*
     export GITHUB_KEY='#{github_key}'
+    mv /root/.ssh/authorized_keys /root/.ssh/authorized_keys.old
     python scripts.d/30_ssh_keys.py
     sudo -u vagrant screen -dmS build sudo bash -c 'export PATH="$PATH:/sbin:/usr/sbin";cd /vagrant;./builder --chroot'
   SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,6 +84,9 @@ Vagrant.configure(2) do |config|
     sudo sh -c 'echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list'
     sudo apt update
     sudo apt install -y kpartx qemu-user-static parted aria2 wget dos2unix python-requests golang-1.14
+    echo "export PATH=$PATH:/usr/lib/go-1.14/bin" >> /home/vagrant/.profile
+    echo "export GOPATH=/home/vagrant/go:$PATH" >> /home/vagrant/.profile
+    source /home/vagrant/.profile
     echo "git checkout <branch> ?"
     mkdir -p /vagrant/images
     cd /vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,7 +88,6 @@ Vagrant.configure(2) do |config|
     cd /vagrant
     dos2unix * */* */*/* */*/*/* */*/*/*/* */*/*/*/*/*
     export GITHUB_KEY='#{github_key}'
-    mv /root/.ssh/authorized_keys /root/.ssh/authorized_keys.old
     python scripts.d/30_ssh_keys.py
     sudo -u vagrant screen -dmS build sudo bash -c 'export PATH="$PATH:/sbin:/usr/sbin";cd /vagrant;./builder --chroot'
   SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(2) do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "treehouses/buster64"
-  config.vm.box_version = "0.1.6"
+  config.vm.box_version = "0.13.3"
 
   config.vm.hostname = "treehouses"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,8 +81,9 @@ Vagrant.configure(2) do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
+    sudo sh -c 'echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list'
     sudo apt update
-    sudo apt install -y kpartx qemu-user-static parted aria2 wget dos2unix python-requests
+    sudo apt install -y kpartx qemu-user-static parted aria2 wget dos2unix python-requests golang-1.14
     echo "git checkout <branch> ?"
     mkdir -p /vagrant/images
     cd /vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,9 +84,9 @@ Vagrant.configure(2) do |config|
     sudo sh -c 'echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list'
     sudo apt update
     sudo apt install -y kpartx qemu-user-static parted aria2 wget dos2unix python-requests golang-1.14
-    echo "export PATH=$PATH:/usr/lib/go-1.14/bin" >> /home/vagrant/.profile
-    echo "export GOPATH=/home/vagrant/go:$PATH" >> /home/vagrant/.profile
-    source /home/vagrant/.profile
+    echo "export PATH=$PATH:/usr/lib/go-1.14/bin" >> ~/.profile
+    echo "export GOPATH=/home/vagrant/go:$PATH" >> ~/.profile
+    source ~/.profile
     echo "git checkout <branch> ?"
     mkdir -p /vagrant/images
     cd /vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,9 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  keys = YAML.load_file('./.vagrant.yml')#GITHUB_KEY: key 
-  github_key = keys.fetch('GITHUB_KEY')
+  vyml = YAML.load_file('./.vagrant.yml')#GITHUB_KEY: key 
+  github_key = vyml.fetch('GITHUB_KEY')
+
   config.vm.box = "treehouses/buster64"
   config.vm.box_version = "0.13.3"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "ole/jessie64"
+  config.vm.box = "treehouses/buster64"
   config.vm.box_version = "0.1.6"
 
   config.vm.hostname = "treehouses"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,8 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
+  keys = YAML.load_file('./.vagrant.yml')#GITHUB_KEY: key 
+  github_key = keys.fetch('GITHUB_KEY')
   config.vm.box = "treehouses/buster64"
   config.vm.box_version = "0.13.3"
 
@@ -79,11 +81,12 @@ Vagrant.configure(2) do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
     sudo apt update
-    sudo apt install -y kpartx qemu-user-static parted aria2 wget dos2unix
+    sudo apt install -y kpartx qemu-user-static parted aria2 wget dos2unix python-requests
     echo "git checkout <branch> ?"
     mkdir -p /vagrant/images
     cd /vagrant
     dos2unix * */* */*/* */*/*/* */*/*/*/* */*/*/*/*/*
+    export GITHUB_KEY='#{github_key}'
     python scripts.d/30_ssh_keys.py
     sudo -u vagrant screen -dmS build sudo bash -c 'export PATH="$PATH:/sbin:/usr/sbin";cd /vagrant;./builder --chroot'
   SHELL

--- a/clean.sh
+++ b/clean.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo rm -rf temp mnt
+sudo rm -rf temp mnt gh-cli


### PR DESCRIPTION
updates the Vagrantfile for current treehouses builds
- change image to `treehouses/buster64`
- add `golang-1.14` to vagrant
- add `.vagrant.yml` for github api key