### PR TITLE
update `30_docker.sh` pip without cache (fixes  #740)

### DIFF
--- a/scripts.d/30_docker.sh
+++ b/scripts.d/30_docker.sh
@@ -58,4 +58,4 @@ cd "$OLD" || die "ERROR: $OLD folder doesn't exist, exiting"
 _op _chroot adduser pi docker
 
 # installs docker-compose using pip3
-_pip3_install docker-compose
+_pip3_install docker-compose --no-cache-dir


### PR DESCRIPTION
prevent pip cache from corrupting vagrant builds

- fixes #740 