### PR TITLE
add ble support (fixes #721)

### DIFF
--- a/scripts.d/16_pkg_install.sh
+++ b/scripts.d/16_pkg_install.sh
@@ -34,6 +34,7 @@ INSTALL_PACKAGES=(
     sl
     mc ranger
     bats # unit testing
+    bluez-hcidump libboost-python-dev libboost-thread-dev libglib2.0-dev #ble support 
 )
 
 if [[ ${INSTALL_PACKAGES:-} ]] ; then

--- a/scripts.d/30_bluetooth.sh
+++ b/scripts.d/30_bluetooth.sh
@@ -10,3 +10,4 @@ echo "Switching bluetooth device class to 0x00010c - computer"
 sed -i -e 's/#Class = .*/Class = 0x00010c/g' mnt/img_root/etc/bluetooth/main.conf
 
 _pip3_install 'pybluez==0.23'
+_pip3_install 'gattlib'


### PR DESCRIPTION
installed gattlib
works on both vagrant and travis
![Screenshot_2020-05-28_00-07-50](https://user-images.githubusercontent.com/3631329/83101893-f975fb80-a078-11ea-9062-2d28316be8ce.png)
![Screenshot_2020-05-28_00-16-37](https://user-images.githubusercontent.com/3631329/83101895-f975fb80-a078-11ea-8f71-0e172921e730.png)

fixes #721