### PR TITLE
update `34_youtube-dl.sh` (fixes #757)

### DIFF
--- a/scripts.d/34_youtube-dl.sh
+++ b/scripts.d/34_youtube-dl.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-ls -al mnt/img_root/usr/local/bin/
-curl -L https://yt-dl.org/downloads/latest/youtube-dl -k -o mnt/img_root/usr/local/bin/youtube-dl 
-ls -al mnt/img_root/usr/local/bin/youtube-dl
+curl -L https://yt-dl.org/downloads/latest/youtube-dl -k -o mnt/img_root/usr/local/bin/youtube-dl #without certificate
 chmod a+rx mnt/img_root/usr/local/bin/youtube-dl

--- a/scripts.d/34_youtube-dl.sh
+++ b/scripts.d/34_youtube-dl.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-curl -L https://yt-dl.org/downloads/latest/youtube-dl -o mnt/img_root/usr/local/bin/youtube-dl
+ls -al mnt/img_root/usr/local/bin/
+curl -L https://yt-dl.org/downloads/latest/youtube-dl -k -o mnt/img_root/usr/local/bin/youtube-dl 
+ls -al mnt/img_root/usr/local/bin/youtube-dl
 chmod a+rx mnt/img_root/usr/local/bin/youtube-dl


### PR DESCRIPTION
Now 34_youtube-dl.sh fetches link without certificate (curl -k)