### PR TITLE
update .gitignore with .vagrant.yml (fixes #766)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ ip/
 mnt/
 temp/
 .vagrant/
-.*.sw[nop]
+.*.sw[nop]/
+.vagrant.yml


### PR DESCRIPTION
adds `.vagrant.yml` to `.gitignore`
fixes #766