### PR TITLE
update 30_ssh_keys.py (fixes #685)

### DIFF
--- a/scripts.d/30_ssh_keys.py
+++ b/scripts.d/30_ssh_keys.py
@@ -11,15 +11,22 @@ headers = {
 }
 
 # Retrieve a list of public members using gitHub API
-members = []
 
-api = 'https://api.github.com/teams/3087744/members'
+def get_members(members,page):
+    api = 'https://api.github.com/teams/3087744/members?per_page=100&page=' + str(page)
 
-request = requests.get(api, headers=headers)
-users = request.json()
-for user in users:
-    members.append(user['login'])
+    request = requests.get(api, headers=headers)
+    users = request.json()
+    for user in users:
+        members.append(user['login'])
+    count = len(users)
 
+    if(count > 0):
+        return get_members(members,page + 1)
+    else:
+        return members
+
+members = get_members([],1)
 print ("Found %d members. Getting keys for users" % len(members))
 
 f = open("authorized_keys", "w")


### PR DESCRIPTION
increases page size to 100 and recursively checks for other pages
now we can have over 30 keys!

- fixes #685