### PR TITLE
travis: switch bionic base image (fixes #775)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ addons:
       - tree
       - python-requests
 
-before_script: df -h
-
 script: mkdir images && sudo PATH=./node_modules/.bin:$PATH ./builder --noninteractive
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: bionic
 
 language: go
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ addons:
       - tree
       - python-requests
 
+before_script: df -h
+
 script: mkdir images && sudo PATH=./node_modules/.bin:$PATH ./builder --noninteractive
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: focal
+dist: bionic
 
 language: go
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: focal
 
 language: go
 go:

--- a/builder
+++ b/builder
@@ -124,9 +124,9 @@ function _open_image {
     echo "Loop-back mounting" "images/$RASPBIAN_IMAGE_FILE"
     # shellcheck disable=SC2086
     kpartx="$(kpartx -sav images/$RASPBIAN_IMAGE_FILE)" || die "Could not setup loop-back access to $RASPBIAN_IMAGE_FILE:$NL$kpartx"
-    df -h
     # shellcheck disable=SC2162
     read -d '' img_boot_dev img_root_dev <<<"$(grep -o 'loop.p.' <<<"$kpartx")"
+    df -h
     test "$img_boot_dev" -a "$img_root_dev" || die "Could not extract boot and root loop device from kpartx output:$NL$kpartx"
     img_boot_dev=/dev/mapper/$img_boot_dev
     img_root_dev=/dev/mapper/$img_root_dev

--- a/builder
+++ b/builder
@@ -124,6 +124,7 @@ function _open_image {
     kpartx="$(kpartx -sav images/$RASPBIAN_IMAGE_FILE)" || die "Could not setup loop-back access to $RASPBIAN_IMAGE_FILE:$NL$kpartx"
     # shellcheck disable=SC2162
     read -d '' img_boot_dev img_root_dev <<<"$(grep -o 'loop.p.' <<<"$kpartx")"
+    df -h
     test "$img_boot_dev" -a "$img_root_dev" || die "Could not extract boot and root loop device from kpartx output:$NL$kpartx"
     img_boot_dev=/dev/mapper/$img_boot_dev
     img_root_dev=/dev/mapper/$img_root_dev

--- a/builder
+++ b/builder
@@ -124,7 +124,7 @@ function _open_image {
     echo "Loop-back mounting" "images/$RASPBIAN_IMAGE_FILE"
     # shellcheck disable=SC2086
     kpartx="$(kpartx -sav images/$RASPBIAN_IMAGE_FILE)" || die "Could not setup loop-back access to $RASPBIAN_IMAGE_FILE:$NL$kpartx"
-    df -h | grep 'loop'
+    df -h
     # shellcheck disable=SC2162
     read -d '' img_boot_dev img_root_dev <<<"$(grep -o 'loop.p.' <<<"$kpartx")"
     test "$img_boot_dev" -a "$img_root_dev" || die "Could not extract boot and root loop device from kpartx output:$NL$kpartx"

--- a/builder
+++ b/builder
@@ -119,12 +119,13 @@ EOF
 }
 
 function _open_image {
+    echo "Stupid Snaps"
+    df -h | grep 'loop'
     echo "Loop-back mounting" "images/$RASPBIAN_IMAGE_FILE"
     # shellcheck disable=SC2086
     kpartx="$(kpartx -sav images/$RASPBIAN_IMAGE_FILE)" || die "Could not setup loop-back access to $RASPBIAN_IMAGE_FILE:$NL$kpartx"
     # shellcheck disable=SC2162
     read -d '' img_boot_dev img_root_dev <<<"$(grep -o 'loop.p.' <<<"$kpartx")"
-    df -h
     test "$img_boot_dev" -a "$img_root_dev" || die "Could not extract boot and root loop device from kpartx output:$NL$kpartx"
     img_boot_dev=/dev/mapper/$img_boot_dev
     img_root_dev=/dev/mapper/$img_root_dev

--- a/builder
+++ b/builder
@@ -168,7 +168,7 @@ function _cleanup_chroot {
 }
 
 function _check_space_left {
-    space_left=$(df | grep 'dev/mapper/loop0p2' | awk '{printf $4}')
+    space_left=$(df | grep 'dev/mapper/loop5p2' | awk '{printf $4}')
     echo "Space left: ${space_left}K"
 }
 

--- a/builder
+++ b/builder
@@ -107,7 +107,7 @@ p
 w
 EOF
     losetup -d /dev/loop6
-    losetup -o $((start_sector*512)) /dev/loop2 "$RESIZE_IMAGE_PATH"
+    losetup -o $((start_sector*512)) /dev/loop7 "$RESIZE_IMAGE_PATH"
     e2fsck -f /dev/loop7
     resize2fs -f /dev/loop7
     losetup -d /dev/loop7

--- a/builder
+++ b/builder
@@ -124,6 +124,7 @@ function _open_image {
     echo "Loop-back mounting" "images/$RASPBIAN_IMAGE_FILE"
     # shellcheck disable=SC2086
     kpartx="$(kpartx -sav images/$RASPBIAN_IMAGE_FILE)" || die "Could not setup loop-back access to $RASPBIAN_IMAGE_FILE:$NL$kpartx"
+    df -h | grep 'loop'
     # shellcheck disable=SC2162
     read -d '' img_boot_dev img_root_dev <<<"$(grep -o 'loop.p.' <<<"$kpartx")"
     test "$img_boot_dev" -a "$img_root_dev" || die "Could not extract boot and root loop device from kpartx output:$NL$kpartx"

--- a/builder
+++ b/builder
@@ -126,8 +126,8 @@ function _open_image {
     kpartx="$(kpartx -sav images/$RASPBIAN_IMAGE_FILE)" || die "Could not setup loop-back access to $RASPBIAN_IMAGE_FILE:$NL$kpartx"
     # shellcheck disable=SC2162
     read -d '' img_boot_dev img_root_dev <<<"$(grep -o 'loop.p.' <<<"$kpartx")"
-    df -h
     test "$img_boot_dev" -a "$img_root_dev" || die "Could not extract boot and root loop device from kpartx output:$NL$kpartx"
+    df -h
     img_boot_dev=/dev/mapper/$img_boot_dev
     img_root_dev=/dev/mapper/$img_root_dev
     mkdir -p mnt/img_root

--- a/builder
+++ b/builder
@@ -93,8 +93,8 @@ function _resize_image {
 
     start_sector=$(fdisk -l "$RESIZE_IMAGE_PATH" | awk -F" "  '{ print $2 }' | sed '/^$/d' | sed -e '$!d')
     truncate -s +$EXTRA_IMAGE_SIZE "$RESIZE_IMAGE_PATH"
-    losetup /dev/loop1 "$RESIZE_IMAGE_PATH"
-    fdisk /dev/loop1 <<EOF
+    losetup /dev/loop6 "$RESIZE_IMAGE_PATH"
+    fdisk /dev/loop6 <<EOF
 p
 d
 2
@@ -106,11 +106,11 @@ $start_sector
 p
 w
 EOF
-    losetup -d /dev/loop1
+    losetup -d /dev/loop6
     losetup -o $((start_sector*512)) /dev/loop2 "$RESIZE_IMAGE_PATH"
-    e2fsck -f /dev/loop2
-    resize2fs -f /dev/loop2
-    losetup -d /dev/loop2
+    e2fsck -f /dev/loop7
+    resize2fs -f /dev/loop7
+    losetup -d /dev/loop7
     if [[ -L "images" ]];
     then
         rsync -Pav "$RASPBIAN_IMAGE_FILE" images/

--- a/builder
+++ b/builder
@@ -127,7 +127,6 @@ function _open_image {
     # shellcheck disable=SC2162
     read -d '' img_boot_dev img_root_dev <<<"$(grep -o 'loop.p.' <<<"$kpartx")"
     test "$img_boot_dev" -a "$img_root_dev" || die "Could not extract boot and root loop device from kpartx output:$NL$kpartx"
-    df -h
     img_boot_dev=/dev/mapper/$img_boot_dev
     img_root_dev=/dev/mapper/$img_root_dev
     mkdir -p mnt/img_root


### PR DESCRIPTION
changing travis from xenial to bionic

- loop0 to loop4 are occupied by snaps installed by ubuntu
- watch out for new snap loops!

- fixes #775 