### PR TITLE
builder: download over aria2c with lpd and dht (fixes #805)

### DIFF
--- a/builder
+++ b/builder
@@ -45,7 +45,7 @@ function _get_image {
     if [ ! -f "$RASPBIAN_TORRENT" ]; then
       wget "$RASPBIAN_TORRENT_URL" -O "$RASPBIAN_TORRENT" || die "Download of $RASPBIAN_TORRENT failed"
     fi
-    aria2c --continue "$RASPBIAN_TORRENT" -d images --seed-time 0
+    aria2c --enable-dht=true --bt-enable-lpd=true --continue "$RASPBIAN_TORRENT" -d images --seed-time 0
     echo -n "Checksum of "
     sha256sum --strict --check - <<<"$RASPBIAN_SHA256 *$IMAGE_ZIP" || die "Download checksum validation failed, please check http://www.raspberrypi.org/downloads"
 }


### PR DESCRIPTION
Local Peer Discovery will enable users to see over LAN when building locally, and DHT will find peers outside of the tracker.

- fixes #805