### PR TITLE
builder: detect loops (fixes #808)

### DIFF
--- a/builder
+++ b/builder
@@ -93,11 +93,11 @@ function _resize_image {
 
     start_sector=$(fdisk -l "$RESIZE_IMAGE_PATH" | awk -F" "  '{ print $2 }' | sed '/^$/d' | sed -e '$!d')
     truncate -s +$EXTRA_IMAGE_SIZE "$RESIZE_IMAGE_PATH"
-    LOOP_BASE=$(losetup -a | grep 'loop' | wc -l) #formerly loop0, loop1, loop2
+    LOOP_BASE=$(losetup -a | grep -c 'loop') #formerly loop0, loop1, loop2
     echo "LOOP BASE: $LOOP_BASE"
-    LOOP_ONE=$(( $LOOP_BASE + 1 ))
+    LOOP_ONE=$(( LOOP_BASE + 1 ))
     echo "LOOP ONE: $LOOP_ONE"
-    LOOP_TWO=$(( $LOOP_BASE + 2 ))
+    LOOP_TWO=$(( LOOP_BASE + 2 ))
     echo "LOOP TWO: $LOOP_TWO"
     truncate -s +$EXTRA_IMAGE_SIZE "$RESIZE_IMAGE_PATH"
     losetup "/dev/loop$LOOP_ONE" "$RESIZE_IMAGE_PATH"

--- a/builder
+++ b/builder
@@ -175,7 +175,7 @@ function _cleanup_chroot {
 }
 
 function _check_space_left {
-    space_left=$(df | grep "dev/mapper/loop$BASE_LOOP\p2" | awk '{printf $4}')
+    space_left=$(df | grep "dev/mapper/loop$LOOP_BASE\p2" | awk '{printf $4}')
     echo "Space left: ${space_left}K"
 }
 

--- a/builder
+++ b/builder
@@ -93,7 +93,7 @@ function _resize_image {
 
     start_sector=$(fdisk -l "$RESIZE_IMAGE_PATH" | awk -F" "  '{ print $2 }' | sed '/^$/d' | sed -e '$!d')
     truncate -s +$EXTRA_IMAGE_SIZE "$RESIZE_IMAGE_PATH"
-    LOOP_BASE=$(df | grep 'loop' | wc -l) #formerly loop0, loop1, loop2
+    LOOP_BASE=$(losetup -a | grep 'loop' | wc -l) #formerly loop0, loop1, loop2
     echo "LOOP BASE: $LOOP_BASE"
     LOOP_ONE=$(( $LOOP_BASE + 1 ))
     echo "LOOP ONE: $LOOP_ONE"
@@ -127,7 +127,7 @@ EOF
 
 function _open_image {
     echo "Stupid Snaps"
-    df -h | grep 'loop'
+    losetup -a | grep 'loop'
     echo "Loop-back mounting" "images/$RASPBIAN_IMAGE_FILE"
     # shellcheck disable=SC2086
     kpartx="$(kpartx -sav images/$RASPBIAN_IMAGE_FILE)" || die "Could not setup loop-back access to $RASPBIAN_IMAGE_FILE:$NL$kpartx"


### PR DESCRIPTION
detects which loops are already in use on the host system before we mount our image. Future proofs travis, may be needed for drone runners.
- fixes (#808)