### PR TITLE
migrate to `focal` (fixes #821)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ before_install:
   - sudo snap remove google-cloud-sdk lxd snapcraft 
   - sudo snap remove core18 
   - sudo snap remove snapd
-  - sudo ls /snap/core/
-  - sudo umount "/snap/core/*"
+  - sudo umount -a
   - sudo apt purge snapd
   - sudo apt-get update
   - sudo apt-get install -t bionic kpartx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: focal
 
 language: go
 go:
@@ -15,7 +15,7 @@ addons:
     packages:
       - qemu-user-static 
       - g++-arm-linux-gnueabihf
-      - kpartx
+      - kpartx=0.7.4-2ubuntu3
       - aria2
       - tree
       - python3-requests

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ before_install:
 
 addons:
   apt:
-    #sources:
-    #  - sourceline: "deb http://us-east-1.ec2.archive.ubuntu.com/ubuntu/ focal universe"
     packages:
       - qemu-user-static 
       - g++-arm-linux-gnueabihf

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 before_install: 
   - snap list
-  - sudo snap remove snap-store gtk-common-themes gnome-3-34-1804 core18 snapd google-cloud-sdk lxd snapcraft
+  - sudo snap remove google-cloud-sdk lxd snapcraft core18 snapd
   - sudo umount /snap/core/*
   - sudo apt purge snapd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
 addons:
   apt:
     sources:
-      - sourceline: "deb http://us-east-1.ec2.archive.ubuntu.com/ubuntu/ focal universe"
+      - sourceline: "deb http://us-east-1.ec2.archive.ubuntu.com/ubuntu/ groovy universe"
     packages:
       - qemu-user-static 
       - g++-arm-linux-gnueabihf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: focal
 
 language: go
 go:
@@ -7,6 +7,12 @@ go:
 
 services:
   - docker
+
+before_install: 
+  - snap list
+  - sudo snap remove snap-store gtk-common-themes gnome-3-34-1804 core18 snapd
+  - sudo umount /snap/core/*
+  - sudo apt purge snapd
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sudo snap remove google-cloud-sdk lxd snapcraft 
   - sudo snap remove core18 
   - sudo snap remove snapd
-  - sudo umount -A
+  # - sudo umount -A
   - sudo apt purge snapd
   - sudo apt-get update
   - sudo apt-get install -t bionic kpartx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: focal
+dist: bionic
 
 language: go
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ before_install:
   - sudo snap remove google-cloud-sdk lxd snapcraft 
   - sudo snap remove core18 
   - sudo snap remove snapd
-  - sudo umount /snap/core/*
+  - sudo ls /snap/core/
+  - sudo umount "/snap/core/*"
   - sudo apt purge snapd
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,13 @@ go:
 services:
   - docker
 
-before_install:
-  - sudo add-apt-repository "deb http://us-east-1.ec2.archive.ubuntu.com/ubuntu/ focal universe"
-  - sudo apt-get update
-  - sudo apt-get install qemu-user-static g++-arm-linux-gnueabihf
-
 addons:
   apt:
+    sources:
+      - sourceline: "deb http://us-east-1.ec2.archive.ubuntu.com/ubuntu/ focal universe"
     packages:
+      - qemu-user-static 
+      - g++-arm-linux-gnueabihf
       - kpartx
       - aria2
       - tree

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 before_install: 
   - snap list
-  - sudo snap remove snap-store gtk-common-themes gnome-3-34-1804 core18 snapd
+  - sudo snap remove snap-store gtk-common-themes gnome-3-34-1804 core18 snapd google-cloud-sdk lxd snapcraft
   - sudo umount /snap/core/*
   - sudo apt purge snapd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: focal
 
 language: go
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
       - kpartx
       - aria2
       - tree
-      - python-requests
+      - python3-requests
 
 script: mkdir images && sudo PATH=./node_modules/.bin:$PATH ./builder --noninteractive
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ before_install:
   - sudo ls /snap/core/
   - sudo umount "/snap/core/*"
   - sudo apt purge snapd
+  - sudo apt-get update
+  - sudo apt-get install -t bionic kpartx
 
 addons:
   apt:
@@ -24,7 +26,7 @@ addons:
     packages:
       - qemu-user-static 
       - g++-arm-linux-gnueabihf
-      - kpartx
+     # - kpartx
       - aria2
       - tree
       - python3-requests

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ services:
 
 before_install: 
   - snap list
-  - sudo snap remove google-cloud-sdk lxd snapcraft core18 snapd
+  - sudo snap remove google-cloud-sdk lxd snapcraft 
+  - sudo snap remove core18 
+  - sudo snap remove snapd
   - sudo umount /snap/core/*
   - sudo apt purge snapd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ before_install:
   - sudo snap remove google-cloud-sdk lxd snapcraft 
   - sudo snap remove core18 
   - sudo snap remove snapd
-  # - sudo umount -A
   - sudo apt purge snapd
-  - sudo apt-get update
-  - sudo apt-get install -t bionic kpartx
 
 addons:
   apt:
@@ -25,7 +22,6 @@ addons:
     packages:
       - qemu-user-static 
       - g++-arm-linux-gnueabihf
-     # - kpartx
       - aria2
       - tree
       - python3-requests

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ services:
 
 addons:
   apt:
-    sources:
-      - sourceline: "deb http://us-east-1.ec2.archive.ubuntu.com/ubuntu/ focal universe"
+    #sources:
+    #  - sourceline: "deb http://us-east-1.ec2.archive.ubuntu.com/ubuntu/ focal universe"
     packages:
       - qemu-user-static 
       - g++-arm-linux-gnueabihf
-      - kpartx=0.7.4-2ubuntu3
+      - kpartx
       - aria2
       - tree
       - python3-requests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: focal
+dist: bionic
 
 language: go
 go:
@@ -11,7 +11,7 @@ services:
 addons:
   apt:
     sources:
-      - sourceline: "deb http://us-east-1.ec2.archive.ubuntu.com/ubuntu/ groovy universe"
+      - sourceline: "deb http://us-east-1.ec2.archive.ubuntu.com/ubuntu/ focal universe"
     packages:
       - qemu-user-static 
       - g++-arm-linux-gnueabihf

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sudo snap remove google-cloud-sdk lxd snapcraft 
   - sudo snap remove core18 
   - sudo snap remove snapd
-  - sudo umount -a
+  - sudo umount -A
   - sudo apt purge snapd
   - sudo apt-get update
   - sudo apt-get install -t bionic kpartx


### PR DESCRIPTION
Migrates the Travis builder from `bionic` to `focal`. 
- snaps have been removed in the process, as they were conflicting with `kpartx`
- `python-requests` package changed to `python3-requests`
- third party repositories are now added via the `sourceline` configuration option

	![image](https://user-images.githubusercontent.com/3631329/96836949-4cc35e80-140b-11eb-88bb-242127c7fcfc.png)
	https://docs.travis-ci.com/user/reference/focal/#differences-from-the-previous-release-images

- fixes #821 