### PR TITLE
changed token variable name (fixes #866)

### DIFF
--- a/builder
+++ b/builder
@@ -2,11 +2,9 @@
 # Download Raspbian Image, remove first-boot stuff, add repos and install packages.
 
 # Raspbian
-#RASPBIAN_TORRENT_URL=http://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2020-05-28/2020-05-27-raspios-buster-armhf.zip.torrent
-RASPBIAN_TORRENT_URL=http://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2020-08-24/2020-08-20-raspios-buster-armhf.zip.torrent
+RASPBIAN_TORRENT_URL=https://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2021-03-25/2021-03-04-raspios-buster-armhf.zip.torrent
 
-#RASPBIAN_SHA256=b9a5c5321b3145e605b3bcd297ca9ffc350ecb1844880afd8fb75a7589b7bd04
-RASPBIAN_SHA256=9d658abe6d97f86320e5a0288df17e6fcdd8776311cc320899719aa805106c52
+RASPBIAN_SHA256=d3de1a33d2d4f4990345b6369960b04c70b577519e6f25f4d7ec601e305e932a 
 
 RASPBIAN_IMAGE_FILE=$(basename $RASPBIAN_TORRENT_URL | sed -e "s/.zip.torrent/.img/g")
 

--- a/scripts.d/20_balena.sh
+++ b/scripts.d/20_balena.sh
@@ -5,7 +5,7 @@ source lib.sh
 echo "Balena installation"
 
 # get the latest version
-releases=$(curl -s https://api.github.com/repos/balena-os/balena-engine/releases/latest -H "Authorization: token $GITHUB_KEY" | jq -r ".assets[].browser_download_url")
+releases=$(curl -s https://api.github.com/repos/balena-os/balena-engine/releases/latest -H "Authorization: token $APIKEY" | jq -r ".assets[].browser_download_url")
 armv6link=$(echo "$releases" | tr " " "\\n" | grep armv6)
 armv7link=$(echo "$releases" | tr " " "\\n" | grep armv7)
 


### PR DESCRIPTION
The reason balena wasn't installing is that the script is calling the old github token variable.