### PR TITLE
update `20_tiv.sh` by locking version (fixes #897)

### DIFF
--- a/scripts.d/20_tiv.sh
+++ b/scripts.d/20_tiv.sh
@@ -5,7 +5,7 @@ git clone https://github.com/stefanhaustein/TerminalImageViewer.git
   cd TerminalImageViewer || exit 0
   workingver=e69c53e4cc03f370fd335b65ccdeb97d3ece294c
   currentver=$(git rev-parse HEAD)
-  [[ "$workingver" != "$currentver" ]] && echo "A new version has been released, test and update the latest release."
+  [[ "$workingver" != "$currentver" ]] && echo "A new version has been released, test and update to the latest release at 'https://github.com/stefanhaustein/TerminalImageViewer'."
   git checkout $workingver
 )
 CXX=arm-linux-gnueabihf-g++ make -C TerminalImageViewer/src/main/cpp

--- a/scripts.d/20_tiv.sh
+++ b/scripts.d/20_tiv.sh
@@ -5,7 +5,7 @@ git clone https://github.com/stefanhaustein/TerminalImageViewer.git
   cd TerminalImageViewer || exit 0
   workingver=e69c53e4cc03f370fd335b65ccdeb97d3ece294c
   currentver=$(git rev-parse HEAD)
-  [[ "$workingver" != "$currentver" ]] && echo "A new version has been released, test and update to the latest release at 'https://github.com/stefanhaustein/TerminalImageViewer'."
+  [[ "$workingver" != "$currentver" ]] && echo "TODO: a new version has been released, check https://github.com/stefanhaustein/TerminalImageViewer"
   git checkout $workingver
 )
 CXX=arm-linux-gnueabihf-g++ make -C TerminalImageViewer/src/main/cpp

--- a/scripts.d/20_tiv.sh
+++ b/scripts.d/20_tiv.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
 git clone https://github.com/stefanhaustein/TerminalImageViewer.git
+(
+  cd TerminalImageViewer || exit 0
+  workingver=e69c53e4cc03f370fd335b65ccdeb97d3ece294c
+  currentver=$(git rev-parse HEAD)
+  [[ "$workingver" != "$currentver" ]] && echo "A new version has been released, test and update the latest release."
+  git checkout $workingver
+)
 CXX=arm-linux-gnueabihf-g++ make -C TerminalImageViewer/src/main/cpp
 mv TerminalImageViewer/src/main/cpp/tiv mnt/img_root/usr/local/bin/


### PR DESCRIPTION
For an example of the test running on a new release of master check out: https://github.com/rjpadilla/versioncheckout/runs/2750789304?check_suite_focus=true#step:2:11